### PR TITLE
fixed floating point number regex, added test

### DIFF
--- a/evaler.go
+++ b/evaler.go
@@ -15,7 +15,7 @@ import (
 )
 
 var whitespace_rx = regexp.MustCompile(`\s+`)
-var fp_rx = regexp.MustCompile(`(\d+(?:\.\d)?)`) // simple fp number
+var fp_rx = regexp.MustCompile(`(\d+(?:\.\d+)?)`) // simple fp number
 var operators = "-+**/<>"
 
 // prec returns the operator's precedence
@@ -176,6 +176,7 @@ func tokenise(expr string) []string {
 		spaced = strings.Replace(spaced, symbol, fmt.Sprintf(" %s ", symbol), -1)
 	}
 	stripped := whitespace_rx.ReplaceAllString(strings.TrimSpace(spaced), "|")
+	fmt.Println(stripped)
 	return strings.Split(stripped, "|")
 }
 

--- a/evaler_test.go
+++ b/evaler_test.go
@@ -30,6 +30,7 @@ var testsEval = []struct {
 	{"5 / 0", nil, false},                        // divide by zero
 	{"2 ** 3", big.NewRat(8, 1), true},           // exponent 1
 	{"9.0**0.5", big.NewRat(3, 1), true},         // exponent 2
+	{"1.23", big.NewRat(123, 100), true},
 }
 
 func TestEval(t *testing.T) {


### PR DESCRIPTION
There was a bug allowing only one digit after the decimal point.
